### PR TITLE
Fixed a bug with 0-min-length list not displaying on initial input-click.

### DIFF
--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -257,7 +257,8 @@ export default {
     },
     onAutocomplete (event) {
       if (hasKeyCode(this.controlScheme.autocomplete, event)
-        && (event.ctrlKey || event.shiftKey) && (this.suggestions.length > 0 && this.suggestions[0])
+        && (event.ctrlKey || event.shiftKey)
+        && (this.suggestions.length > 0 && this.suggestions[0])
       ) {
         event.preventDefault()
         this.select(this.suggestions[0])

--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -205,7 +205,7 @@ export default {
       }
     },
     showList () {
-      if (!this.listShown && this.text.length >= this.minLength) {
+      if (!this.listShown && ((this.text && this.text.length) || 0) >= this.minLength) {
         if (this.suggestions.length > 0) {
           this.listShown = true
           this.$emit('show-list')
@@ -213,7 +213,7 @@ export default {
       }
     },
     async onInputClick (event) {
-      if (this.minLength === 0 && !this.text) {
+      if (this.suggestions.length === 0 && this.minLength === 0 && !this.text) {
         await this.research()
       }
 


### PR DESCRIPTION
## **Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## **What kind of change does this PR introduce?**

Bug Fix

## **What is the current behavior?**

Currently, if the component has `min-length` equal to 0, on initial input click there would be an exception about `text` being `null`.
Also, even with putting that aside, the suggestions on input click would not always show if `text`'s length is 0 with corresponding min-length.

## **What is the new behavior?**

With this PR, the suggestion list is shown correctly on input click with `min-length` of 0.

## **Does this PR introduce a breaking change?**

No. It's a fix