### PR TITLE
Fix the documentation to use `vue-simple-suggest` instead of `vue-suggest`. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ Then, in your Vue.js component/page:
 ```html
 <!-- Some component.vue -->
 <template>
-  <vue-suggest
+  <vue-simple-suggest
     v-model="chosen"
     :list="simpleSuggestionList"
     :filter-by-query="true">
 <!-- Filter by input text to only show the matching results -->
-  </vue-suggest>
+  </vue-simple-suggest>
 
   <br>
 

--- a/README.md
+++ b/README.md
@@ -95,12 +95,12 @@ Then, in your Vue.js component/page:
 </template>
 
 <script>
-  import VueSuggest from 'vue-simple-suggest'
+  import VueSimpleSuggest from 'vue-simple-suggest'
   import 'vue-simple-suggest/dist/styles.css' // Optional CSS
 
   export default {
     components: {
-      VueSuggest
+      VueSimpleSuggest
     },
     data() {
       return {


### PR DESCRIPTION
Why does the sample uses `vue-suggest` ? I tried the example and I got this error message:

> [Vue warn]: Unknown custom element: <vue-suggest> - did you register the component correctly? For recursive components, make sure to provide the "name" option.

The moment I changed it to `vue-simple-suggest` it works.
