### PR TITLE
fix #81

### DIFF
--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -156,6 +156,7 @@ export default {
       isClicking: false,
       isOverList: false,
       isInFocus: false,
+      isFalseFocus: false,
       isTabbed: false,
       controlScheme: {}
     }
@@ -377,7 +378,10 @@ export default {
 
           this.$emit('blur', e)
         } else if (e && e.isTrusted && !this.isTabbed) {
-          this.inputElement.focus()
+          this.isFalseFocus = true
+          this.$nextTick(() => {
+            this.inputElement.focus()
+          })
         }
       } else {
         this.inputElement.blur()
@@ -393,9 +397,10 @@ export default {
       this.isInFocus = true
 
       // Only emit, if it was a native input focus
-      if (e && e.sourceCapabilities) {
+      if (e && !this.isFalseFocus) {
         this.$emit('focus', e)
       }
+      this.isFalseFocus = false
 
       // Show list only if the item has not been clicked
       if (!this.isClicking) {


### PR DESCRIPTION
## **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix:
Firefox treats ticks differently from Chrome and others. Due to this, the focus event happened before the browser was ready for it.
Now the focus event is emitted on a correct tick for every major browser to grasp it.


## **What is the current behavior?** (You can also link to an open issue here)
Issue #81


## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.