### PR TITLE
Feature/accessibility wai aria support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ See [installation guide](#installation) for more options.
       - [Ref Data](#ref-data)
     - [Slots](#slots)
         - [Custom input](#custom-input)
+          - [Accessibility on custom input](#accessibility-on-custom-input)
         - [Custom suggestion item](#custom-suggestion-item)
         - [Custom miscellanious item slots](#custom-miscellanious-item-slots)
 
@@ -473,7 +474,7 @@ A proper use-case for it being when one wants to use the component only for sele
 | `focus`         | HTML focus event            | An outward projection of the current input's event.                                                    |
 | `blur`          | HTML focus event            | An outward projection of the current input's event.                                                    |
 | `select`        | Selected suggestion         | Fires on suggestion selection (via a mouse click or enter keypress).                                   |
-| `hover`         | Hovered suggestion, target element, target element `id` property          | Fires each time a new suggestion is highlighted (via a cursor movement or keyboard arrows).            |
+| `hover`         | Hovered suggestion, target element          | Fires each time a new suggestion is highlighted (via a cursor movement or keyboard arrows).            |
 | `suggestion-click`        | Selected suggestion, HTML click event        | Fires on suggestion element click.                                   |
 | `show-list`      | -                           | Fires each time the suggestion list is toggled to be shown.                                            |
 | `hide-list`      | -                           | Fires each time the suggestion list is being hidden.                                                   |
@@ -611,37 +612,19 @@ If `vue-simple-suggest` with your custom component doesn't seem to react to outs
 </vue-simple-suggest>
 ```
 
-**Accessibility on custom input:**
+##### Accessibility on custom input:
 
-`vue-simple-suggest`'s default `input` element includes these ARIA attributes:
+`vue-simple-suggest` automatically injects 3 necessary ARIA attributes for the default `<input>` element
+and any custom input, as long as your custom input component contains an html `<input>` element.
 
-| Name                | Value                 | Description                            |
-|---------------------|-------------------------|----------------------------------------|
-| aria-autocomplete     | `"list"`                | Indicates that the autocomplete behavior of the text input is to suggest a list of possible values in a popup. |
-| aria-controls         | `"suggestions"`         | IDREF of the popup element that lists suggested values. |
-| aria-activedescendant | IDREF of hovered option | Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the input element. IDREF is returned as the 3rd parameter of the `hover` event. |
+These attributes ensure that the autocomplete can be used by users who rely on Screen Readers.
 
-When using a custom `input` element make sure to include these 3 attributes.
-```html
-<!-- Example: -->
-<vue-simple-suggest @hover="onSuggestHover">
-  <input
-    type="text"
-    :aria-activedescendant="hoveredId || ''"
-    aria-autocomplete='list'
-    aria-controls="suggestions">
-</vue-simple-suggest>
-```
+| Name                  | Value                              | Description                            |
+|-----------------------|------------------------------------|----------------------------------------|
+| aria-autocomplete     | `"list"`                           | Indicates that the autocomplete behavior of the text input is to suggest a list of possible values in a popup. |
+| aria-controls         | IDREF of `suggestions` list        | IDREF of the popup element that lists suggested values. |
+| aria-activedescendant | IDREF of hovered option            | Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the input element. |
 
-```javascript
-...
-methods: {
-  onSuggestHover (suggestion, elem, elemId) {
-    this.hoveredId = elemId
-  },
-  ...
-}
-```
 
 ##### Custom suggestion item
 > `suggestion-item` slot (optional)

--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ A proper use-case for it being when one wants to use the component only for sele
 | `focus`         | HTML focus event            | An outward projection of the current input's event.                                                    |
 | `blur`          | HTML focus event            | An outward projection of the current input's event.                                                    |
 | `select`        | Selected suggestion         | Fires on suggestion selection (via a mouse click or enter keypress).                                   |
-| `hover`         | Hovered suggestion          | Fires each time a new suggestion is highlighted (via a cursor movement or keyboard arrows).            |
+| `hover`         | Hovered suggestion, target element, target element `id` property          | Fires each time a new suggestion is highlighted (via a cursor movement or keyboard arrows).            |
 | `suggestion-click`        | Selected suggestion, HTML click event        | Fires on suggestion element click.                                   |
 | `show-list`      | -                           | Fires each time the suggestion list is toggled to be shown.                                            |
 | `hide-list`      | -                           | Fires each time the suggestion list is being hidden.                                                   |
@@ -609,6 +609,38 @@ If `vue-simple-suggest` with your custom component doesn't seem to react to outs
 <vue-simple-suggest v-model="model">
   <my-custom-input-somponent v-model="model"></my-custom-input-somponent>
 </vue-simple-suggest>
+```
+
+**Accessibility on custom input:**
+
+`vue-simple-suggest`'s default `input` element includes these ARIA attributes:
+
+| Name                | Value                 | Description                            |
+|---------------------|-------------------------|----------------------------------------|
+| aria-autocomplete     | `"list"`                | Indicates that the autocomplete behavior of the text input is to suggest a list of possible values in a popup. |
+| aria-controls         | `"suggestions"`         | IDREF of the popup element that lists suggested values. |
+| aria-activedescendant | IDREF of hovered option | Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the input element. IDREF is returned as the 3rd parameter of the `hover` event. |
+
+When using a custom `input` element make sure to include these 3 attributes.
+```html
+<!-- Example: -->
+<vue-simple-suggest @hover="onSuggestHover">
+  <input
+    type="text"
+    :aria-activedescendant="hoveredId || ''"
+    aria-autocomplete='list'
+    aria-controls="suggestions">
+</vue-simple-suggest>
+```
+
+```javascript
+...
+methods: {
+  onSuggestHover (suggestion, elem, elemId) {
+    this.hoveredId = elemId
+  },
+  ...
+}
 ```
 
 ##### Custom suggestion item

--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -40,11 +40,21 @@
         @request-failed="onRequestFailed"
         @show-list="onShowList"
         @hide-list="onHideList">
-        <!-- <input type="text"> -->
+        <!-- <input
+          :aria-activedescendant="hoveredId || ''"
+          aria-autocomplete='list'
+          aria-controls="suggestions"
+          type="text"> -->
 
-        <!-- <div class="g"><input type="text"></div> -->
+        <!-- <div class="g">
+          <input
+            :aria-activedescendant="hoveredId || ''"
+            aria-autocomplete='list'
+            aria-controls="suggestions"
+            type="text">
+        </div> -->
 
-        <test-input placeholder="Search information..."/>
+        <test-input placeholder="Search information..." :aria-activedescendant="hoveredId"/>
 
         <template slot="misc-item-above" slot-scope="{ suggestions, query }">
           <div class="misc-item">
@@ -107,7 +117,8 @@
         model: null,
         mode: 'input',
         loading: false,
-        log: []
+        log: [],
+        hoveredId: null
       }
     },
     methods: {
@@ -154,8 +165,9 @@
         this.addToLog('select', suggest)
         this.selected = suggest
       },
-      onSuggestHover (suggestion) {
+      onSuggestHover (suggestion, elem, elemId) {
         this.addToLog('hover', suggestion);
+        this.hoveredId = elemId
       },
       onRequestStart (value) {
         this.loading = true

--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -40,21 +40,13 @@
         @request-failed="onRequestFailed"
         @show-list="onShowList"
         @hide-list="onHideList">
-        <!-- <input
-          :aria-activedescendant="hoveredId || ''"
-          aria-autocomplete='list'
-          aria-controls="suggestions"
-          type="text"> -->
+        <!-- <input type="text"> -->
 
         <div class="g">
-          <input
-            :aria-activedescendant="hoveredId || ''"
-            aria-autocomplete='list'
-            aria-controls="suggestions"
-            type="text">
+          <input type="text">
         </div>
 
-        <!-- <test-input placeholder="Search information..." :aria-activedescendant="hoveredId"/> -->
+        <!-- <test-input placeholder="Search information..." /> -->
 
         <template slot="misc-item-above" slot-scope="{ suggestions, query }">
           <div class="misc-item">
@@ -117,8 +109,7 @@
         model: null,
         mode: 'input',
         loading: false,
-        log: [],
-        hoveredId: null
+        log: []
       }
     },
     methods: {
@@ -165,9 +156,8 @@
         this.addToLog('select', suggest)
         this.selected = suggest
       },
-      onSuggestHover (suggestion, elem, elemId) {
+      onSuggestHover (suggestion) {
         this.addToLog('hover', suggestion);
-        this.hoveredId = elemId
       },
       onRequestStart (value) {
         this.loading = true

--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -46,15 +46,15 @@
           aria-controls="suggestions"
           type="text"> -->
 
-        <!-- <div class="g">
+        <div class="g">
           <input
             :aria-activedescendant="hoveredId || ''"
             aria-autocomplete='list'
             aria-controls="suggestions"
             type="text">
-        </div> -->
+        </div>
 
-        <test-input placeholder="Search information..." :aria-activedescendant="hoveredId"/>
+        <!-- <test-input placeholder="Search information..." :aria-activedescendant="hoveredId"/> -->
 
         <template slot="misc-item-above" slot-scope="{ suggestions, query }">
           <div class="misc-item">

--- a/example/src/README.html
+++ b/example/src/README.html
@@ -21,16 +21,38 @@
 <pre class="hljs"><code>npm install --save vue-simple-suggest</code></pre><p>See <a href="#installation">installation guide</a> for more options.</p>
 <h2 id="table-of-contents"><a class="header-link" href="#table-of-contents"></a>Table of contents</h2>
 <ul class="list">
-<li><a href="#what-is-it">What is it?</a></li>
+<li><a href="#vue-simple-suggest">vue-simple-suggest</a><ul class="list">
+<li><a href="#install">Install</a></li>
+<li><a href="#table-of-contents">Table of contents</a></li>
+<li><a href="#what-is-it">What is it</a><ul class="list">
+<li><a href="#features">Features</a></li>
+<li><a href="#new-features">New features?</a></li>
+</ul>
+</li>
 <li><a href="#simple-example">Simple example</a></li>
-<li><a href="#installation">Installation</a></li>
-<li><a href="#build-setup">Build</a></li>
-<li><a href="#default-controls">Controls</a></li>
+<li><a href="#installation">Installation</a><ul class="list">
+<li><a href="#npm">NPM</a></li>
+<li><a href="#unpkg">Unpkg</a></li>
+<li><a href="#importing">Importing</a><ul class="list">
+<li><a href="#polyfills">Polyfills</a></li>
+</ul>
+</li>
+<li><a href="#usage">Usage</a></li>
+</ul>
+</li>
+<li><a href="#build-setup">Build Setup</a></li>
+<li><a href="#default-controls">Default Controls</a></li>
 <li><a href="#component-api">Component API</a><ul class="list">
 <li><a href="#tldr">TLDR</a></li>
-<li><a href="#css-class-structure">CSS class structure &amp; Transitions</a></li>
-<li><a href="#api-definitions">API Definitions</a><ul class="list">
-<li><a href="#props">Props</a></li>
+<li><a href="#css-class-structure">CSS class structure</a><ul class="list">
+<li><a href="#transitions">Transitions</a></li>
+</ul>
+</li>
+<li><a href="#api-definitions">API definitions</a><ul class="list">
+<li><a href="#props">Props</a><ul class="list">
+<li><a href="#mode">mode</a></li>
+</ul>
+</li>
 <li><a href="#emitted-events">Emitted Events</a></li>
 <li><a href="#ref-methods">Ref Methods</a></li>
 <li><a href="#ref-event-handlers">Ref Event Handlers</a></li>
@@ -41,6 +63,8 @@
 <li><a href="#custom-input">Custom input</a></li>
 <li><a href="#custom-suggestion-item">Custom suggestion item</a></li>
 <li><a href="#custom-miscellanious-item-slots">Custom miscellanious item slots</a></li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>
@@ -68,6 +92,7 @@
 <li><a href="#css-class-structure">CSS classes</a> for quick and easy restyling.</li>
 <li>Many build variants to choose from.</li>
 <li>Flexible and customizable component design.</li>
+<li>Optional polyfills for IE importable from the lib.</li>
 </ul>
 <p>All of the props, events and slots are OPTIONAL for this component, so it can be used without any configuration at all.</p>
 <h3 id="new-features?"><a class="header-link" href="#new-features?"></a>New features?</h3>
@@ -153,7 +178,15 @@ yarn add vue-simple-suggest</code></pre><h3 id="unpkg"><a class="header-link" hr
 <span class="hljs-comment">///</span>
 
 <span class="hljs-comment">// Optional - import css separately with css loaders:</span>
-<span class="hljs-keyword">import</span> <span class="hljs-string">'vue-simple-suggest/dist/styles.css'</span></code></pre><h3 id="usage"><a class="header-link" href="#usage"></a>Usage</h3>
+<span class="hljs-keyword">import</span> <span class="hljs-string">'vue-simple-suggest/dist/styles.css'</span></code></pre><h4 id="polyfills"><a class="header-link" href="#polyfills"></a>Polyfills</h4>
+<blockquote>
+<p>New in <code>v1.8.3</code></p>
+</blockquote>
+<p><code>vue-simple-suggest</code> comes with minimal optional polyfills for IE11+ - <code>Object.assign</code>, <code>Element.prototype.closest</code> and <code>Element.prototype.matches</code>.
+You can import them like this:</p>
+<pre class="hljs"><code><span class="hljs-keyword">import</span> <span class="hljs-string">'vue-simple-suggest/lib/polyfills'</span>;
+<span class="hljs-comment">// or</span>
+<span class="hljs-built_in">require</span>(<span class="hljs-string">'vue-simple-suggest/lib/polyfills'</span>);</code></pre><h3 id="usage"><a class="header-link" href="#usage"></a>Usage</h3>
 <p><strong>Globaly:</strong></p>
 <pre class="hljs"><code><span class="hljs-comment">// You don't need to do it, if including via &lt;script&gt; (umd, iife)</span>
 Vue.component(<span class="hljs-string">'vue-simple-suggest'</span>, VueSimpleSuggest)</code></pre><p><strong>In single-file .vue components:</strong></p>
@@ -457,7 +490,7 @@ npm run docs</code></pre><hr>
 <td>All of the HTML5 input attributes with their respected default values.</td>
 </tr>
 <tr>
-<td><code>prevent-submit</code></td>
+<td><code>prevent-submit</code> <sup>v1.8.1</sup></td>
 <td>Boolean</td>
 <td><code>true</code></td>
 <td>Whether to prevent form submitting when <code>Enter</code> key is pressed.</td>
@@ -507,7 +540,7 @@ npm run docs</code></pre><hr>
 </tr>
 <tr>
 <td><code>hover</code></td>
-<td>Hovered suggestion</td>
+<td>Hovered suggestion, target element, target element <code>id</code> property</td>
 <td>Fires each time a new suggestion is highlighted (via a cursor movement or keyboard arrows).</td>
 </tr>
 <tr>
@@ -803,7 +836,49 @@ Defaults to a simple input with props passed to vue-simple-suggest.</p>
 <p>If <code>vue-simple-suggest</code> with your custom component doesn&#39;t seem to react to outside variable changes - bind both components&#39; v-model to the same variable, like so:</p>
 <pre class="hljs"><code><span class="hljs-tag">&lt;<span class="hljs-name">vue-simple-suggest</span> <span class="hljs-attr">v-model</span>=<span class="hljs-string">"model"</span>&gt;</span>
   <span class="hljs-tag">&lt;<span class="hljs-name">my-custom-input-somponent</span> <span class="hljs-attr">v-model</span>=<span class="hljs-string">"model"</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">my-custom-input-somponent</span>&gt;</span>
-<span class="hljs-tag">&lt;/<span class="hljs-name">vue-simple-suggest</span>&gt;</span></code></pre><h5 id="custom-suggestion-item"><a class="header-link" href="#custom-suggestion-item"></a>Custom suggestion item</h5>
+<span class="hljs-tag">&lt;/<span class="hljs-name">vue-simple-suggest</span>&gt;</span></code></pre><p><strong>Accessibility on custom input:</strong></p>
+<p><code>vue-simple-suggest</code>&#39;s default <code>input</code> element includes these ARIA attributes:</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>aria-autocomplete</td>
+<td><code>&quot;list&quot;</code></td>
+<td>Indicates that the autocomplete behavior of the text input is to suggest a list of possible values in a popup.</td>
+</tr>
+<tr>
+<td>aria-controls</td>
+<td><code>&quot;suggestions&quot;</code></td>
+<td>IDREF of the popup element that lists suggested values.</td>
+</tr>
+<tr>
+<td>aria-activedescendant</td>
+<td>IDREF of hovered option</td>
+<td>Enables assistive technologies to know which element the application regards as focused while DOM focus remains on the input element. IDREF is returned as the 3rd parameter of the <code>hover</code> event.</td>
+</tr>
+</tbody>
+</table>
+<p>When using a custom <code>input</code> element make sure to include these 3 attributes.</p>
+<pre class="hljs"><code><span class="hljs-comment">&lt;!-- Example: --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">vue-simple-suggest</span> @<span class="hljs-attr">hover</span>=<span class="hljs-string">"onSuggestHover"</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">input</span>
+    <span class="hljs-attr">type</span>=<span class="hljs-string">"text"</span>
+    <span class="hljs-attr">:aria-activedescendant</span>=<span class="hljs-string">"hoveredId || ''"</span>
+    <span class="hljs-attr">aria-autocomplete</span>=<span class="hljs-string">'list'</span>
+    <span class="hljs-attr">aria-controls</span>=<span class="hljs-string">"suggestions"</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">vue-simple-suggest</span>&gt;</span></code></pre><pre class="hljs"><code>...
+methods: {
+  onSuggestHover (suggestion, elem, elemId) {
+    <span class="hljs-keyword">this</span>.hoveredId = elemId
+  },
+  ...
+}</code></pre><h5 id="custom-suggestion-item"><a class="header-link" href="#custom-suggestion-item"></a>Custom suggestion item</h5>
 <blockquote>
 <p><code>suggestion-item</code> slot (optional)</p>
 </blockquote>

--- a/example/src/TestInput.vue
+++ b/example/src/TestInput.vue
@@ -1,5 +1,12 @@
 <template>
-  <input type="text" @input.stop="onInput" @blur.stop="onBlur" @focus.stop="onFocus" :value="value">
+  <input
+  v-bind="$attrs"
+  type="text"
+  @input.stop="onInput"
+  @blur.stop="onBlur"
+  @focus.stop="onFocus"
+  aria-autocomplete='list'
+  aria-controls="suggestions">
 </template>
 
 <script>

--- a/example/src/TestInput.vue
+++ b/example/src/TestInput.vue
@@ -1,12 +1,5 @@
 <template>
-  <input
-  v-bind="$attrs"
-  type="text"
-  @input.stop="onInput"
-  @blur.stop="onBlur"
-  @focus.stop="onFocus"
-  aria-autocomplete='list'
-  aria-controls="suggestions">
+  <input type="text" @input.stop="onInput" @blur.stop="onBlur" @focus.stop="onFocus">
 </template>
 
 <script>

--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -202,10 +202,6 @@ export default {
     this.controlScheme = Object.assign({}, defaultControls, this.controls)
   },
   mounted () {
-
-    console.log('$misc-item-below',!!this.$scopedSlots['misc-item-below']);
-    console.log('$misc-item-above',!!this.$scopedSlots['misc-item-above']);
-    
     this.inputElement = this.$refs['inputSlot'].querySelector('input')
 
     this.setInputAriaAttributes()

--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -548,7 +548,8 @@ export default {
 </script>
 
 <style>
-.vue-simple-suggest .suggestions {
+
+.vue-simple-suggest ul {
   list-style: none;
   margin: 0;
   padding: 0;

--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -549,7 +549,7 @@ export default {
 
 <style>
 
-.vue-simple-suggest ul {
+.vue-simple-suggest > ul {
   list-style: none;
   margin: 0;
   padding: 0;

--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -6,19 +6,18 @@
     <div class="input-wrapper" ref="inputSlot"
       role="combobox"
       aria-haspopup="listbox"
-      aria-owns="suggestions"
+      :aria-owns="listId"
       :aria-expanded="!!listShown && !removeList ? 'true' : 'false'"
       :class="styles.inputWrapper">
       <slot>
         <input class="default-input" v-bind="$attrs" :value="text || ''"
-          aria-autocomplete='list'
-          aria-controls="suggestions"
-          :aria-activedescendant="!!hovered ? getId(hovered, hoveredIndex) : ''"
           :class="styles.defaultInput">
       </slot>
     </div>
     <transition name="vue-simple-suggest">
-      <ul id="suggestions" class="suggestions" v-if="!!listShown && !removeList"
+      <ul :id="listId" class="suggestions" v-if="!!listShown && !removeList"
+        role="listbox"
+        :aria-labelledby="listId"
         :class="styles.suggestions"
         @mouseenter="hoverList(true)"
         @mouseleave="hoverList(false)"
@@ -172,7 +171,8 @@ export default {
       isInFocus: false,
       isFalseFocus: false,
       isTabbed: false,
-      controlScheme: {}
+      controlScheme: {},
+      listId: `${this._uid}-suggestions`
     }
   },
   computed: {
@@ -204,6 +204,7 @@ export default {
   mounted () {
     this.inputElement = this.$refs['inputSlot'].querySelector('input')
 
+    this.setInputAriaAttributes()
     this.prepareEventHandlers(true)
   },
   beforeDestroy () {
@@ -215,6 +216,11 @@ export default {
         e.stopPropagation()
         e.preventDefault()
       }
+    },
+    setInputAriaAttributes () {
+      this.inputElement.setAttribute('aria-activedescendant', '')
+      this.inputElement.setAttribute('aria-autocomplete', 'list')
+      this.inputElement.setAttribute('aria-controls', this.listId)
     },
     prepareEventHandlers(enable) {
       const binder = this[enable ? 'on' : 'off']
@@ -288,6 +294,7 @@ export default {
     },
     hover (item, elem, elemId) {
       this.hovered = item
+      this.inputElement.setAttribute('aria-activedescendant',  !!item ? this.getId(item, this.hoveredIndex) : '')
       if (item !== undefined) {
         this.$emit('hover', item, elem, elemId)
       }
@@ -534,7 +541,7 @@ export default {
       this.suggestions.splice(0)
     },
     getId(value, i) {
-      return `suggestion-${this.isPlainSuggestion ? i : this.valueProperty(value)}`
+      return `${this.listId}-suggestion-${this.isPlainSuggestion ? i : this.valueProperty(value)}`
     }
   }
 }

--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -320,6 +320,7 @@ export default {
       this.showList()
     },
     moveSelection (e) {
+      if (!this.listShown || !this.suggestions.length) return
       if (hasKeyCode([this.controlScheme.selectionUp, this.controlScheme.selectionDown], e)) {
         e.preventDefault()
         this.showSuggestions()

--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -22,7 +22,7 @@
         @mouseenter="hoverList(true)"
         @mouseleave="hoverList(false)"
       >
-        <li>
+        <li v-if="!!this.$scopedSlots['misc-item-above']">
           <slot name="misc-item-above"
             :suggestions="suggestions"
             :query="text"
@@ -50,7 +50,7 @@
           </slot>
         </li>
 
-        <li>
+        <li v-if="!!this.$scopedSlots['misc-item-below']">
           <slot name="misc-item-below"
             :suggestions="suggestions"
             :query="text"
@@ -202,6 +202,10 @@ export default {
     this.controlScheme = Object.assign({}, defaultControls, this.controls)
   },
   mounted () {
+
+    console.log('$misc-item-below',!!this.$scopedSlots['misc-item-below']);
+    console.log('$misc-item-above',!!this.$scopedSlots['misc-item-above']);
+    
     this.inputElement = this.$refs['inputSlot'].querySelector('input')
 
     this.setInputAriaAttributes()

--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -548,6 +548,12 @@ export default {
 </script>
 
 <style>
+.vue-simple-suggest .suggestions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 .vue-simple-suggest.designed {
   position: relative;
 }
@@ -574,9 +580,6 @@ export default {
 }
 
 .vue-simple-suggest.designed .suggestions {
-  list-style: none;
-  margin: 0;
-  padding: 0;
   position: absolute;
   left: 0;
   right: 0;

--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -4,27 +4,39 @@
     @keydown.tab="isTabbed = true"
   >
     <div class="input-wrapper" ref="inputSlot"
+      role="combobox"
+      aria-haspopup="listbox"
+      aria-owns="suggestions"
+      :aria-expanded="!!listShown && !removeList ? 'true' : 'false'"
       :class="styles.inputWrapper">
       <slot>
         <input class="default-input" v-bind="$attrs" :value="text || ''"
+          aria-autocomplete='list'
+          aria-controls="suggestions"
+          :aria-activedescendant="valueProperty(hovered)"
           :class="styles.defaultInput">
       </slot>
     </div>
     <transition name="vue-simple-suggest">
-      <div class="suggestions" v-if="!!listShown && !removeList"
+      <ul id="suggestions" class="suggestions" v-if="!!listShown && !removeList"
         :class="styles.suggestions"
         @mouseenter="hoverList(true)"
         @mouseleave="hoverList(false)"
       >
-        <slot name="misc-item-above"
-          :suggestions="suggestions"
-          :query="text"
-        ></slot>
+        <li>
+          <slot name="misc-item-above"
+            :suggestions="suggestions"
+            :query="text"
+          ></slot>
+        </li>
 
-        <div class="suggest-item" v-for="(suggestion, index) in suggestions"
+        <li class="suggest-item" v-for="(suggestion, index) in suggestions"
+          role="option"
           @mouseenter="hover(suggestion, $event.target)"
           @mouseleave="hover(null, $event.target)"
           @click="suggestionClick(suggestion, $event)"
+          :aria-selected="hovered && (valueProperty(hovered) == valueProperty(suggestion)) ? 'true' : 'false'"
+          :id="isPlainSuggestion ? 'suggestion-' + index : valueProperty(suggestion)"
           :key="isPlainSuggestion ? 'suggestion-' + index : valueProperty(suggestion)"
           :class="[
             styles.suggestItem,{
@@ -37,13 +49,15 @@
             :query="text">
             <span>{{ displayProperty(suggestion) }}</span>
           </slot>
-        </div>
+        </li>
 
-        <slot name="misc-item-below"
-          :suggestions="suggestions"
-          :query="text"
-        ></slot>
-      </div>
+        <li>
+          <slot name="misc-item-below"
+            :suggestions="suggestions"
+            :query="text"
+          ></slot>
+        </li>
+      </ul>
     </transition>
   </div>
 </template>
@@ -548,6 +562,9 @@ export default {
 }
 
 .vue-simple-suggest.designed .suggestions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   position: absolute;
   left: 0;
   right: 0;

--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -31,7 +31,7 @@
 
         <li class="suggest-item" v-for="(suggestion, index) in suggestions"
           role="option"
-          @mouseenter="hover(suggestion, $event.target, getId(suggestion, index))"
+          @mouseenter="hover(suggestion, $event.target)"
           @mouseleave="hover(undefined)"
           @click="suggestionClick(suggestion, $event)"
           :aria-selected="hovered && (valueProperty(hovered) == valueProperty(suggestion)) ? 'true' : 'false'"
@@ -292,11 +292,13 @@ export default {
       this.hover(null)
       this.autocompleteText(this.displayProperty(item))
     },
-    hover (item, elem, elemId) {
+    hover (item, elem) {
       this.hovered = item
-      this.inputElement.setAttribute('aria-activedescendant',  !!item ? this.getId(item, this.hoveredIndex) : '')
+      const elemId = !!item ? this.getId(item, this.hoveredIndex) : ''
+
+      this.inputElement.setAttribute('aria-activedescendant',  elemId)
       if (item !== undefined) {
-        this.$emit('hover', item, elem, elemId)
+        this.$emit('hover', item, elem)
       }
     },
     hoverList (isOverList) {
@@ -341,14 +343,12 @@ export default {
 
         if (!this.hovered) {
           item = this.selected || this.suggestions[listEdge]
-          this.hover(item, undefined, this.getId(item, listEdge))
         } else if (hoversBetweenEdges) {
           item = this.suggestions[this.hoveredIndex + direction]
-          this.hover(item, undefined, this.getId(item, this.hoveredIndex + direction))
         } else /* if hovers on edge */ {
           item = this.suggestions[listEdge]
-          this.hover(item, undefined, this.getId(item, listEdge))
         }
+        this.hover(item)
       }
     },
     onListKeyUp (e) {
@@ -540,7 +540,7 @@ export default {
     clearSuggestions () {
       this.suggestions.splice(0)
     },
-    getId(value, i) {
+    getId (value, i) {
       return `${this.listId}-suggestion-${this.isPlainSuggestion ? i : this.valueProperty(value)}`
     }
   }

--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -13,7 +13,7 @@
         <input class="default-input" v-bind="$attrs" :value="text || ''"
           aria-autocomplete='list'
           aria-controls="suggestions"
-          :aria-activedescendant="valueProperty(hovered)"
+          :aria-activedescendant="!!hovered && getId(hovered, hoveredIndex)"
           :class="styles.defaultInput">
       </slot>
     </div>
@@ -36,8 +36,8 @@
           @mouseleave="hover(null, $event.target)"
           @click="suggestionClick(suggestion, $event)"
           :aria-selected="hovered && (valueProperty(hovered) == valueProperty(suggestion)) ? 'true' : 'false'"
-          :id="isPlainSuggestion ? 'suggestion-' + index : valueProperty(suggestion)"
-          :key="isPlainSuggestion ? 'suggestion-' + index : valueProperty(suggestion)"
+          :id="getId(suggestion, index)"
+          :key="getId(suggestion, index)"
           :class="[
             styles.suggestItem,{
             selected: selected && (valueProperty(suggestion) == valueProperty(selected)),
@@ -530,6 +530,9 @@ export default {
     },
     clearSuggestions () {
       this.suggestions.splice(0)
+    },
+    getId(value, i) {
+      return `suggestion-${this.isPlainSuggestion ? i : this.valueProperty(value)}`
     }
   }
 }

--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -411,6 +411,7 @@ export default {
       const value = !inputEvent.target ? inputEvent : inputEvent.target.value
 
       if (this.text === value) { return }
+      if (this.hovered) this.hovered = null
 
       this.text = value
       this.$emit('input', this.text)


### PR DESCRIPTION
## **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Accessibility features.


## **What is the current behavior?** (You can also link to an open issue here)
Closes #103


## **What is the new behavior (if this is a feature change)?**

- New aria-attributes added to the input element.
- Changes suggestions list element from to a `<ul>` and each item into `<li>`
- Resets previous `hovered` value on input.
- `hover` emits `null` when list is closed
- ~~Adds 3rd argument: `elemId` (wil be the IDREF of hovered list item) for `hover` methods, to let the `aria-activedescendant` to be set for custom input.~~
- Escapes the `moveSelection` before emitting if list is empty or not shown

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Changing the list and items to `<ul>` and `<li>` elements added some new css.
For anyone who doesn't use the default styling provided by `vue-simple-suggest`, this might cause fall back to the default browser values, ie. `list-style: disc;`.

## **Other information**:
