### PR TITLE
fix prevent submit

### DIFF
--- a/lib/misc.js
+++ b/lib/misc.js
@@ -16,9 +16,13 @@ export function fromPath(obj, path) {
 }
 
 export function hasKeyCode(arr, event) {
+  return hasKeyCodeByCode(arr, event.keyCode)
+}
+
+export function hasKeyCodeByCode(arr, keyCode) {
   if (arr.length <= 0) return false
 
-  const has = arr => arr.some(code => code === event.keyCode)
+  const has = arr => arr.some(code => code === keyCode)
   if (Array.isArray(arr[0])) {
     return arr.some(array => has(array))
   } else {

--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -66,6 +66,7 @@ import {
   defaultControls,
   modes,
   fromPath,
+  hasKeyCodeByCode,
   hasKeyCode
 } from './misc'
 
@@ -241,12 +242,6 @@ export default {
     isHovered (suggestion) {
       return this.isEqual(suggestion, this.hovered)
     },
-    onSubmit (e) {
-      if (this.preventSubmit && e.key === 'Enter') {
-        e.stopPropagation()
-        e.preventDefault()
-      }
-    },
     setInputAriaAttributes () {
       this.inputElement.setAttribute('aria-activedescendant', '')
       this.inputElement.setAttribute('aria-autocomplete', 'list')
@@ -256,7 +251,7 @@ export default {
       const binder = this[enable ? 'on' : 'off']
       const keyEventsList = {
         click: this.showSuggestions,
-        keydown: $event => (this.moveSelection($event), this.onAutocomplete($event)),
+        keydown: this.onKeyDown,
         keyup: this.onListKeyUp
       }
       const eventsList = Object.assign({
@@ -273,13 +268,6 @@ export default {
 
       for (const event in keyEventsList) {
         this.inputElement[listenerBinder](event, keyEventsList[event])
-      }
-
-      if (this.preventSubmit === true) {
-        let form = this.$el.closest('form')
-        if (form) {
-          form[listenerBinder]('keydown', this.onSubmit)
-        }
       }
     },
     isScopedSlotEmpty (slot) {
@@ -423,6 +411,18 @@ export default {
         }
         this.hover(item)
       }
+    },
+    onKeyDown(e) {
+      const select = this.controlScheme.select,
+          hideList = this.controlScheme.hideList
+
+      // prevent form submit on keydown if Enter key registered in the keyup list
+      if (this.preventSubmit && e.key === 'Enter' && hasKeyCodeByCode([select, hideList], 13)) {
+        e.preventDefault();
+      }
+
+      this.moveSelection(e);
+      this.onAutocomplete(e);
     },
     onListKeyUp (e) {
       const select = this.controlScheme.select,


### PR DESCRIPTION
## **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix #134 



## **What is the current behavior?** (You can also link to an open issue here)
#134 
Prevent submit for every input of the form


## **What is the new behavior (if this is a feature change)?**
Prevent submit only for VSS input

Note: I have added check for presence of Enter key in the keyUp controlScheme items: `select` and `hideList`. Because of no reason to prevent submit of the form, if no functionality will be provided by VSS. Otherwise, without this check and without Enter key in the controlScheme pressing Enter will do nothing at all, I think it will be pretty strange :)



## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes



## **Other information**:
There is a strange behavior of VSS that this PR does not fix.
If we disable `preventSubmit` and press Enter key while dropdown is opened next things occur:
- Enter keydown will submit form, because it is not prevented
- Enter keyup will `select` value after form submission

I'm not sure if it should be handled as a new issue or during this PR.

I think there is three options:
- Always prevent form submit when dropdown is opened and apply `preventSubmit` option only if Enter pressed on the input with closed dropdown
- Move `select` logic to keydown event
- Postpone keydown form submission and fire it only after `select` was done in the keyup event
