### PR TITLE
add showList control

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Default scheme:
 |Key (key code) | Description|
 |-|-|
 |`Escape` (27) | If the suggestions list is shown - hide it. Defined by `hideList` property. |
-|`ArrowDown` (40) | If the suggestions list is hidden - show it.  Defined by `selectionDown` property. |
+|`ArrowDown` (40) | If the suggestions list is hidden - show it.  Defined by `showList` property. |
 |`ArrowUp` (38) / `ArrowDown` (40) | Cycle (hover) through suggestions.  Defined by `selectionUp`/`selectionDown` properties respectfully. |
 |`Enter` (13) | If the list is shown - chooses the highlighted element, if the list is hidden - refills the suggestions based on current input text.  Defined by `select` property.|
 |`(Ctrl/Shift) + Space` (32) | Select the first element in the list.  Defined by `autocomplete` property. Works with `Ctrl` modifier key or `Shift` modifier key. |
@@ -274,6 +274,7 @@ JS object:
   selectionUp: [38],
   selectionDown: [40],
   select: [13],
+  showList: [40],
   hideList: [27],
   autocomplete: [32, 13]
 }
@@ -307,6 +308,7 @@ JS object:
     selectionUp: [38, 33],
     selectionDown: [40, 34],
     select: [13, 36],
+    showList: [40],
     hideList: [27, 35],
     autocomplete: [32, 13],
   }"

--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -23,6 +23,7 @@
           selectionUp: [38, 33],
           selectionDown: [40, 34],
           select: [13, 36],
+          showList: [40],
           hideList: [27, 35]
         }"
         :mode="mode"

--- a/lib/misc.js
+++ b/lib/misc.js
@@ -3,6 +3,7 @@ export const defaultControls = {
   selectionDown: [40],
   select: [13],
   hideList: [27],
+  showList: [40],
   autocomplete: [32, 13]
 }
 

--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -389,11 +389,15 @@ export default {
 
       this.showList()
     },
+    onShowList(e) {
+      if (hasKeyCode(this.controlScheme.showList, e)) {
+        this.showSuggestions()
+      }
+    },
     moveSelection (e) {
       if (!this.listShown || !this.suggestions.length) return
       if (hasKeyCode([this.controlScheme.selectionUp, this.controlScheme.selectionDown], e)) {
         e.preventDefault()
-        this.showSuggestions()
 
         const isMovingDown = hasKeyCode(this.controlScheme.selectionDown, e)
         const direction = isMovingDown * 2 - 1
@@ -421,6 +425,7 @@ export default {
         e.preventDefault();
       }
 
+      this.onShowList(e)
       this.moveSelection(e);
       this.onAutocomplete(e);
     },


### PR DESCRIPTION
## **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix, feature


## **What is the current behavior?** (You can also link to an open issue here)
In the docs stated, that `selectionDown` should open suggestions list, but it is not worked, I guess it's a bug.



## **What is the new behavior (if this is a feature change)?**
`selectionDown` control is no more responsible for list opening.
New `showList` control added to take care of list opening. (And it works now)


## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Well, `selectionDown` was not open list and don't open list now too, so in this sense, it is not breaking change.
However, if developer expect `selectionDown` to open list and he added or changed keys for this control, then he will need to update to new `showList` control



## **Other information**:
This change allows adding ArrowUp to the `showList` control to align with browser's datalist, mentioned in the #166
If you don't mind I can update this PR and add ArrowUp to the default `showList` control. But it will be a bit more breaking change :)