### PR TITLE
fix firefox blur on suggestion click

### DIFF
--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -453,13 +453,10 @@ export default {
     suggestionClick (suggestion, e) {
       this.$emit('suggestion-click', suggestion, e)
       this.select(suggestion)
+      this.hideList()
 
       /// Ensure, that all needed flags are off before finishing the click.
       this.isClicking = this.isOverList = false
-
-      this.$nextTick(() => {
-        this.hideList()
-      })
     },
     onBlur (e) {
       if (this.isInFocus) {
@@ -475,9 +472,9 @@ export default {
           this.$emit('blur', e)
         } else if (e && e.isTrusted && !this.isTabbed) {
           this.isFalseFocus = true
-          this.$nextTick(() => {
+          setTimeout(() => {
             this.inputElement.focus()
-          })
+          }, 0)
         }
       } else {
         this.inputElement.blur()
@@ -500,12 +497,13 @@ export default {
       if (e && !this.isFalseFocus) {
         this.$emit('focus', e)
       }
-      this.isFalseFocus = false
 
-      // Show list only if the item has not been clicked
-      if (!this.isClicking) {
+      // Show list only if the item has not been clicked (isFalseFocus indicates that click was made earlier)
+      if (!this.isClicking && !this.isFalseFocus) {
         this.showSuggestions()
       }
+
+      this.isFalseFocus = false
     },
     onInput (inputEvent) {
       const value = !inputEvent.target ? inputEvent : inputEvent.target.value


### PR DESCRIPTION
## **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix



## **What is the current behavior?** (You can also link to an open issue here)
#187


## **What is the new behavior (if this is a feature change)?**
Forcing focus on blur was moved to the end of task queue with setTimeout instead of moving to microtask queue with $nextTick

It is a common workaround for the Firefox [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=53579)


## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No 



## **Other information**:
I also have reverted the fix 6afe79a3a5f2e97ff5c1614d0128b7168db2715e of #100 Because it didn’t work anymore. 

And implemented more appropriate fix for #100 by disabling `showSuggestions` within `onFocus` when `isFalseFocus === true`

Looks like earlier it worked, beacuse microstask [$nextTick hideList](https://github.com/KazanExpress/vue-simple-suggest/blob/v1.9.6/lib/vue-simple-suggest.vue#L463) was fired after microtask [$nextTick inputElement.focus()](https://github.com/KazanExpress/vue-simple-suggest/blob/v1.9.6/lib/vue-simple-suggest.vue#L481)
which contains [onFocus showSuggestions](https://github.com/KazanExpress/vue-simple-suggest/blob/v1.9.6/lib/vue-simple-suggest.vue#L509)

I have tested this patch in latest Firefox, Chrome and iOS Safari