### PR TITLE
fix stuck focus

### DIFF
--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -19,8 +19,6 @@
         role="listbox"
         :aria-labelledby="listId"
         :class="styles.suggestions"
-        @mouseenter="hoverList(true)"
-        @mouseleave="hoverList(false)"
       >
         <li v-if="!!this.$scopedSlots['misc-item-above']">
           <slot name="misc-item-above"
@@ -181,7 +179,6 @@ export default {
       text: this.value,
       isPlainSuggestion: false,
       isClicking: false,
-      isOverList: false,
       isInFocus: false,
       isFalseFocus: false,
       isTabbed: false,
@@ -354,9 +351,6 @@ export default {
 
       this.hovered = item
     },
-    hoverList (isOverList) {
-      this.isOverList = isOverList
-    },
     hideList () {
       if (this.listShown) {
         this.listShown = false
@@ -457,14 +451,14 @@ export default {
       this.hideList()
 
       /// Ensure, that all needed flags are off before finishing the click.
-      this.isClicking = this.isOverList = false
+      this.isClicking = false
     },
     onBlur (e) {
       if (this.isInFocus) {
 
         /// Clicking starts here, because input's blur occurs before the suggestionClick
         /// and exactly when the user clicks the mouse button or taps the screen.
-        this.isClicking = this.isOverList && !this.isTabbed
+        this.isClicking = this.hovered && !this.isTabbed
 
         if (!this.isClicking) {
           this.isInFocus = false


### PR DESCRIPTION
## **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix



## **What is the current behavior?** (You can also link to an open issue here)
#297 


## **What is the new behavior (if this is a feature change)?**
Focus works properly


## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No



## **Other information**:
Instead of fixing `isOverList` I have used `hovered`. Looks like `hovered` doing pretty same but is not broken.
However, I'm not 100% sure we can rely on `hovered` here. So if `isOverList` is really needed we can think about different approach to fix this.
What do you think?
