### PR TITLE
Replace Array.prototype.findIndex with a for statement (for IE11 compatibility)

### DIFF
--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -206,7 +206,13 @@ export default {
       return this.inputIsComponent ? '$off' : 'removeEventListener'
     },
     hoveredIndex () {
-      return this.suggestions.findIndex(el => this.hovered && (this.valueProperty(this.hovered) == this.valueProperty(el)))
+      for (let i = 0; i < this.suggestions.length; i++) {
+        const el = this.suggestions[i];
+        if (this.hovered && (this.valueProperty(this.hovered) == this.valueProperty(el))) {
+          return i;
+        }
+      }
+      return -1;
     },
     textLength () {
       return (this.text && this.text.length) || (this.inputElement.value.length) || 0


### PR DESCRIPTION
## **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

I replaced `Array.prototype.findIndex` with a `for statement` for IE11 compatibility.
IE11 cann't use the `findIndex` method.
https://caniuse.com/#feat=array-find-index

## **What is the current behavior?** (You can also link to an open issue here)

I get an error when using the `selectionUp` or `selectionDown` in IE11.

## **What is the new behavior (if this is a feature change)?**

The keyboard shortcuts can be used in IE11.

## **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Not included.

## **Other information**:
