### PR TITLE
"select" event can return a null item even when the nullableSelect property is set to false

### DIFF
--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -30,7 +30,7 @@
         <li class="suggest-item" v-for="(suggestion, index) in suggestions"
           role="option"
           @mouseenter="hover(suggestion, $event.target)"
-          @mouseleave="hover(undefined)"
+          @mouseleave="hover(null)"
           @click="suggestionClick(suggestion, $event)"
           :aria-selected="(isHovered(suggestion) || isSelected(suggestion)) ? 'true' : 'false'"
           :id="getId(suggestion, index)"

--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -347,7 +347,7 @@ export default {
       })
     },
     select (item) {
-      if (this.selected !== item || (this.nullableSelect && !item)) {
+      if ((item && this.selected !== item) || (this.nullableSelect && !item)) {
         this.selected = item
         this.$emit('select', item)
 


### PR DESCRIPTION
Hi,
Sometimes the "select" event doesn't return a non-null element when used this way:
```
<vue-simple-suggest
   @select="setValueFromSuggestion"
   ...
```

To reproduce the problem with a vue-simple-suggest component:
1. write something in the input field
2. hover the suggestions with the mouse (but don't select a suggestion)
3. press enter (the focus must still be in the input field)
4. the setValueFromSuggestion function will retrieve an null/undefined item

Fortunately, the fix is quite simple.

Thierry.
