### PR TITLE
vue-simple-suggest should not mutate the array provided to the "list" property

### DIFF
--- a/lib/vue-simple-suggest.vue
+++ b/lib/vue-simple-suggest.vue
@@ -624,7 +624,7 @@ export default {
 
       finally {
         if (this.maxSuggestions) {
-          result.splice(this.maxSuggestions)
+          result = result.slice(0, this.maxSuggestions)
         }
 
         this.isPlainSuggestion = nextIsPlainSuggestion


### PR DESCRIPTION
Hi,
currently vue-simple-suggest mutates any array supplied to the "list" property when the "max-suggestions" property is used.

```
<vue-simple-suggest
    :list="listOfSuggestions"
    :max-suggestions="99"
    ...
/>
```

This breaks the [One-Way Data Flow](https://v2.vuejs.org/v2/guide/components-props#One-Way-Data-Flow) recommended by Vue and affects parent state by triggering any watcher on the `listOfSuggestions` list, etc...

The reason for this property mutation is that the library internally uses the `splice()` function on the provided list, instead of using the `slice()` function which returns an array copy.

Thierry.
